### PR TITLE
adding dependency on calibration_msgs_gencpp to all targets that need it

### DIFF
--- a/image_cb_detector/CMakeLists.txt
+++ b/image_cb_detector/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(image_cb_detector_action ${Boost_LIBRARIES}
                                                ${OpenCV_LIBRARIES}
                                                ${PCL_LIBRARIES}
 )
+add_dependencies(image_cb_detector_action calibration_msgs_gencpp)
 
 add_executable(rgbd_cb_detector_action src/rgbd_cb_detector_action.cpp)
 target_link_libraries(rgbd_cb_detector_action ${Boost_LIBRARIES}
@@ -61,6 +62,7 @@ target_link_libraries(rgbd_cb_detector_action ${Boost_LIBRARIES}
                                               ${OpenCV_LIBRARIES}
                                               ${PCL_LIBRARIES}
 )
+add_dependencies(rgbd_cb_detector_action calibration_msgs_gencpp)
 
 add_executable(image_annotator src/image_annotator.cpp)
 target_link_libraries(image_annotator image_cb_detector ${OpenCV_LIBRARIES} ${PCL_LIBRARIES})
@@ -70,6 +72,7 @@ target_link_libraries(image_annotator ${Boost_LIBRARIES}
                                       ${OpenCV_LIBRARIES}
                                       ${PCL_LIBRARIES}
 )
+add_dependencies(image_annotator calibration_msgs_gencpp)
 
 install(TARGETS image_cb_detector_action rgbd_cb_detector_action image_annotator
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/interval_intersection/CMakeLists.txt
+++ b/interval_intersection/CMakeLists.txt
@@ -24,6 +24,7 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/interval_intersection/
 #common commands for building c++ executables and libraries
 add_library(${PROJECT_NAME} src/interval_intersection.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+add_dependencies(${PROJECT_NAME} calibration_msgs_gencpp)
 
 install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -32,6 +33,7 @@ install(TARGETS ${PROJECT_NAME}
 # deal with the executable
 add_executable(interval_intersection_node src/interval_intersection_node.cpp)
 target_link_libraries(interval_intersection_node ${PROJECT_NAME})
+add_dependencies(interval_intersection_node calibration_msgs_gencpp)
 
 include_directories(SYSTEM ${BOOST_INCLUDE_DIRS})
 add_executable(interval_intersection_action src/interval_intersection_action.cpp)

--- a/joint_states_settler/CMakeLists.txt
+++ b/joint_states_settler/CMakeLists.txt
@@ -36,9 +36,11 @@ add_executable(joint_states_settler_action src/joint_states_settler_action.cpp)
 target_link_libraries(joint_states_settler_action ${Boost_LIBRARIES}
                                                   ${PROJECT_NAME}
 )
+add_dependencies(joint_states_settler_action calibration_msgs_gencpp)
 
 add_executable(view_interval src/view_interval.cpp)
 target_link_libraries(view_interval ${catkin_LIBRARIES})
+add_dependencies(view_interval calibration_msgs_gencpp)
 
 install(TARGETS joint_states_settler_action view_interval
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/laser_cb_detector/CMakeLists.txt
+++ b/laser_cb_detector/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(laser_interval_calc_node ${Boost_LIBRARIES}
                                                ${PROJECT_NAME}
                                                ${OpenCV_LIBRARIES}
 )
+add_dependencies(laser_interval_calc_node calibration_msgs_gencpp)
 
 install(TARGETS laser_cb_detector_node laser_interval_calc_node
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/laser_cb_detector/test/CMakeLists.txt
+++ b/laser_cb_detector/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 catkin_add_gtest(cv_laser_bridge_unittest     cv_laser_bridge_unittest.cpp)
 target_link_libraries(cv_laser_bridge_unittest laser_cb_detector)
-
+add_dependencies(cv_laser_bridge_unittest calibration_msgs_gencpp)
 
 catkin_add_gtest(laser_cb_detector_unittest     laser_cb_detector_unittest.cpp)
 target_link_libraries(laser_cb_detector_unittest laser_cb_detector)

--- a/monocam_settler/CMakeLists.txt
+++ b/monocam_settler/CMakeLists.txt
@@ -32,7 +32,6 @@ install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 
-
 # deal with the executable
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 add_executable(monocam_settler_action src/monocam_settler_action.cpp)
@@ -43,5 +42,6 @@ target_link_libraries(monocam_settler_action ${Boost_LIBRARIES}
 install(TARGETS monocam_settler_action
         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
+add_dependencies(monocam_settler_action calibration_msgs_gencpp)
 
 add_subdirectory(test EXCLUDE_FROM_ALL)

--- a/settlerlib/CMakeLists.txt
+++ b/settlerlib/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(${PROJECT_NAME} src/interval_calc.cpp
                             src/deflated.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+add_dependencies(${PROJECT_NAME} calibration_msgs_gencpp)
 
 install(TARGETS ${PROJECT_NAME}
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
This way everything compiles in the first run.
