### PR TITLE
multi_step_cov_estimator: added 'default_initial_pose' parameter

### DIFF
--- a/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
+++ b/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
@@ -254,9 +254,12 @@ if __name__ == '__main__':
         previous_pose_guesses = numpy.array(yaml.load(config['initial_poses']))
     else:
         previous_pose_guesses = numpy.zeros([msg_count,6])
+        
+        # TODO: add alternate methods of defining default poses guesses
+        # See https://github.com/ros-perception/calibration/pull/9
         if 'default_initial_pose' in config.keys():
             for p in range(msg_count):
-                previous_pose_guesses[p,] = config['default_initial_pose']
+                previous_pose_guesses[p,] = config['default_floating_initial_pose']
 
     # Check if we can write to all of our output files
     output_filenames = [calibrated_xml]

--- a/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
+++ b/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
@@ -49,6 +49,7 @@ import stat
 import os
 
 from numpy import matrix
+from numpy import multiply
 
 from calibration_estimation.cal_bag_helpers import *
 from calibration_estimation.urdf_params import UrdfParams
@@ -254,6 +255,9 @@ if __name__ == '__main__':
         previous_pose_guesses = numpy.array(yaml.load(config['initial_poses']))
     else:
         previous_pose_guesses = numpy.zeros([msg_count,6])
+        if 'default_initial_pose' in config.keys():
+            for p in range(msg_count):
+                previous_pose_guesses[p,] = config['default_initial_pose']
 
     # Check if we can write to all of our output files
     output_filenames = [calibrated_xml]

--- a/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
+++ b/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
@@ -260,7 +260,7 @@ if __name__ == '__main__':
         if 'default_floating_initial_pose' in config.keys():
             default_pose = config['default_floating_initial_pose']
             if len(default_pose) != 6:
-                print "The 'default_initial_pose' parameter has", len(default_pose), "elements, but it should have 6!"
+                print "The 'default_floating_initial_pose' parameter has", len(default_pose), "elements, but it should have 6!"
                 sys.exit(-1)
             for p in range(msg_count):
                 previous_pose_guesses[p,] = config['default_floating_initial_pose']

--- a/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
+++ b/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
@@ -257,7 +257,11 @@ if __name__ == '__main__':
         
         # TODO: add alternate methods of defining default poses guesses
         # See https://github.com/ros-perception/calibration/pull/9
-        if 'default_initial_pose' in config.keys():
+        if 'default_floating_initial_pose' in config.keys():
+            default_pose = config['default_floating_initial_pose']
+            if len(default_pose) != 6:
+                print "The 'default_initial_pose' parameter has", len(default_pose), "elements, but it should have 6!"
+                sys.exit(-1)
             for p in range(msg_count):
                 previous_pose_guesses[p,] = config['default_floating_initial_pose']
 

--- a/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
+++ b/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
@@ -49,7 +49,6 @@ import stat
 import os
 
 from numpy import matrix
-from numpy import multiply
 
 from calibration_estimation.cal_bag_helpers import *
 from calibration_estimation.urdf_params import UrdfParams


### PR DESCRIPTION
This will replace the previously used value [0 0 0 0 0 0] as initial pose guess by an (optional) parameter placed in the system.yaml. On dewey, the calibration woudn't converge otherwise.

Not sure about this. Maybe this should go into the 'checkerboards' section.

Example system.yaml:

```
base_link: base_link

sensors:

  chains:
    torso_chain:
      root: base_link
      tip: head_tilt_link
      cov:
       joint_angles: [0.01, 0.01, 0.01, 0.01, 0.01]
      gearing: [1.0, 1.0, 1.0, 1.0, 1.0]

  rectified_cams:
    head_camera:
      chain_id: torso_chain
      frame_id: head_camera_rgb_optical_frame
      baseline_shift: 0.0
      baseline_rgbd: 0.075
      f_shift: 0.0
      cx_shift: 0.0
      cy_shift: 0.0
      cov: {u: 0.25, v: 0.25, x: 0.25}
    base_camera:
      chain_id: NONE
      frame_id: base_camera_rgb_optical_frame
      baseline_shift: 0.0
      baseline_rgbd: 0.075
      f_shift: 0.0
      cx_shift: 0.0
      cy_shift: 0.0
      cov: {u: 0.25, v: 0.25, x: 0.25}

  tilting_lasers: {}

checkerboards:
  cb_7x6:
    corners_x: 7
    corners_y: 6
    spacing_x: 0.108
    spacing_y: 0.108

transforms:
  dummy_transform:   [ 0, 0, 0, 0, 0, 0 ]

default_initial_pose: [ 3, 0, 0, 0, 0, 0 ]
```
