### PR TITLE
Added support for empty / low-dimensionality chains

### DIFF
--- a/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
+++ b/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
@@ -57,6 +57,15 @@ from calibration_estimation.opt_runner import opt_runner
 
 from calibration_estimation.single_transform import angle_axis_to_RPY, RPY_to_angle_axis
 
+# Re-enable Ctrl+C cancelling
+import signal
+def signal_handler(signal, frame):
+    print '\n\nYou pressed Ctrl+C!\n'
+    sys.exit(-1)
+        
+signal.signal(signal.SIGINT, signal_handler)
+
+
 def usage():
     rospy.logerr("Not enough arguments")
     print "Usage:"

--- a/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
+++ b/calibration_estimation/src/calibration_estimation/multi_step_cov_estimator.py
@@ -218,6 +218,8 @@ def update_urdf(urdf, calibrated_params):
                     link_updated = 1                
         except KeyError:
             print "Joint removed:", joint_name
+            print ' xyz:', updated_link_params[0:3]
+            print ' rpy:', angle_axis_to_RPY(updated_link_params[3:6])
             link_updated = 1
         if not link_updated:
             unchanged_joints.append( joint_name );

--- a/calibration_estimation/src/calibration_estimation/sensors/chain_sensor.py
+++ b/calibration_estimation/src/calibration_estimation/sensors/chain_sensor.py
@@ -134,6 +134,12 @@ class ChainSensor:
             Jt[i] = (fTest - f0)/epsilon
         cov_angles = [x*x for x in self._full_chain.calc_block._chain._cov_dict['joint_angles']]
         cov = matrix(Jt).T * matrix(diag(cov_angles)) * matrix(Jt)
+        
+        if ( self._full_chain.calc_block._chain._cov_dict.has_key('translation') ):
+            translation_var = self._full_chain.calc_block._chain._cov_dict['translation'];
+            translation_cov = numpy.diag(translation_var*(self.get_residual_length()/3))
+            cov = cov + translation_cov
+
         return cov
 
     def get_residual_length(self):

--- a/settlerlib/src/interval_calc.cpp
+++ b/settlerlib/src/interval_calc.cpp
@@ -35,6 +35,7 @@
 //! \author Vijay Pradeep
 
 #include <sstream>
+#include <limits>
 #include <settlerlib/interval_calc.h>
 #include <ros/console.h>
 
@@ -66,6 +67,14 @@ calibration_msgs::Interval IntervalCalc::computeLatestInterval(const SortedDeque
   assert(*rev_it);  // Make sure it's not a NULL pointer
 
   const unsigned int N = (*rev_it)->channels_.size();
+
+  // if we have zero channels, the interval goes from zero to the end of time
+  if ( N == 0 )
+  {
+    calibration_msgs::Interval result;
+    result.end.sec = std::numeric_limits<typeof result.end.sec>::max();
+    return result;
+  }
 
   assert(tolerances.size() == N);
   vector<double> channel_max( (*rev_it)->channels_ );

--- a/settlerlib/src/interval_calc.cpp
+++ b/settlerlib/src/interval_calc.cpp
@@ -72,7 +72,7 @@ calibration_msgs::Interval IntervalCalc::computeLatestInterval(const SortedDeque
   if ( N == 0 )
   {
     calibration_msgs::Interval result;
-    result.end.sec = std::numeric_limits<typeof result.end.sec>::max();
+    result.end.sec = std::numeric_limits<uint32_t>::max();
     return result;
   }
 


### PR DESCRIPTION
These additions bring in an optional configuration parameter to add a diagonal covariance matrix on top of the one that comes out of the forward kinematics jacobian. Also, it adds a handling for empty chains so they are always settled instead of never.

There's another small fix in there for catching Ctrl+C. Without this, you can only cancel the estimation by killing the process from outside. Let me know if you want this to be in a separate pull request.
