### PR TITLE
Build failure on Hydro

### DIFF
--- a/calibration_estimation/setup.py
+++ b/calibration_estimation/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    packages=['calibration_estimation', 'calibration_estimation.sensors', 'urdf_python'],
+    packages=['calibration_estimation', 'calibration_estimation.sensors'],
     package_dir={'': 'src'},
     install_requires=['genpy', 'numpy', 'rosgraph', 'roslib', 'rospkg'],
     )


### PR DESCRIPTION
On the farm (http://jenkins.ros.org/view/HbinP32/job/ros-hydro-calibration-estimation_binarydeb_precise_i386/14/console):

```
copying src/calibration_estimation/sensors/multi_sensor.py -> /tmp/buildd/ros-hydro-calibration-estimation-0.10.1-0precise-20130830-0631/obj-i686-linux-gnu/lib.linux-x86_64-2.7/calibration_estimation/sensors
error: package directory 'src/urdf_python' does not exist
CMake Error at catkin_generated/safe_execute_install.cmake:4 (message):

  execute_process(/tmp/buildd/ros-hydro-calibration-estimation-0.10.1-0precise-20130830-0631/obj-i686-linux-gnu/catkin_generated/python_distutils_install.sh)
  returned error code
Call Stack (most recent call first):
  cmake_install.cmake:51 (INCLUDE)


make[1]: *** [install] Error 1
make[1]: Leaving directory `/tmp/buildd/ros-hydro-calibration-estimation-0.10.1-0precise-20130830-0631/obj-i686-linux-gnu'
dh_auto_install: make -j1 install DESTDIR=/tmp/buildd/ros-hydro-calibration-estimation-0.10.1-0precise-20130830-0631/debian/ros-hydro-calibration-estimation returned exit code 2
make: *** [binary] Error 29
dpkg-buildpackage: error: fakeroot debian/rules binary gave error exit status 2
```
