### PR TITLE
Export architecture_independent flag in package.xml

### DIFF
--- a/calibration_estimation/package.xml
+++ b/calibration_estimation/package.xml
@@ -23,4 +23,8 @@
   <run_depend>tf</run_depend>
   <run_depend>urdfdom_py</run_depend>
   <run_depend>visualization_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/calibration_launch/package.xml
+++ b/calibration_launch/package.xml
@@ -18,4 +18,8 @@
   <run_depend>urdfdom_py</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/calibration_msgs/package.xml
+++ b/calibration_msgs/package.xml
@@ -24,4 +24,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>


### PR DESCRIPTION
These packages don't have any binaries in them, so they can be marked as architecture independent.

Tested on the RPM buildfarm (http://csc.mcs.sdsmt.edu/jenkins/):
- [x] No regressions
- [x] No binaries installed

See:
- https://github.com/ros/rosdistro/issues/4037
- https://github.com/ros-infrastructure/bloom/pull/270
- http://www.ros.org/reps/rep-0127.html#architecture-independent

Thanks!
