### PR TITLE
axis is already list

### DIFF
--- a/calibration_estimation/src/calibration_estimation/urdf_params.py
+++ b/calibration_estimation/src/calibration_estimation/urdf_params.py
@@ -176,7 +176,7 @@ class UrdfParams:
                         print 'Joint origin is rotated, calibration will fail: ', joint_name
                 elif urdf.joint_map[joint_name].joint_type == 'prismatic':
                     this_config["active_joints"].append(joint_name)
-                    axis = list(urdf.joint_map[joint_name].axis.split())
+                    axis = urdf.joint_map[joint_name].axis
                     this_config["axis"].append( sum( [i[0]*int(i[1]) for i in zip([1,2,3], axis)] ) )
                 elif urdf.joint_map[joint_name].joint_type != 'fixed':
                     print 'Unknown joint type:', urdf.joint_map[joint_name].joint_type


### PR DESCRIPTION
joint_map[].axis returns list so we do not need to split and list.

```
>>> robot.joint_map['HEAD_JOINT0'].axis
[0.0, 0.0, 1.0]
```

c.f.
need https://github.com/ros/urdfdom/pull/46 to work this package.
