### PR TITLE
check if input depth image is 32bit

### DIFF
--- a/image_cb_detector/src/rgbd_cb_detector_action.cpp
+++ b/image_cb_detector/src/rgbd_cb_detector_action.cpp
@@ -44,6 +44,7 @@
 #include <opencv2/core/core_c.h>
 
 #include <sensor_msgs/Image.h>
+#include <sensor_msgs/image_encodings.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <image_cb_detector/ConfigAction.h>
 #include <calibration_msgs/Interval.h>
@@ -130,6 +131,9 @@ public:
       const float* depth_ptr = reinterpret_cast<const float*>(&depth_msg->data[0]);
       std::size_t width = depth_msg->width;
       std::size_t height = depth_msg->height;
+      if(depth_msg->encoding != sensor_msgs::image_encodings::TYPE_32FC1) {
+          ROS_ERROR_STREAM("Disparity image must be 32-bit floating point (encoding '32FC1'), but has encoding '" << depth_msg->encoding << "'");
+      }
 
       // make a pointcloud from the checkerboard corners
       std::vector<cv::Point3f> corner_cloud;


### PR DESCRIPTION
the program only takes 32bit float depth image

```
      const float* depth_ptr = reinterpret_cast<const float*>(&depth_msg->data[0]);
```

(https://github.com/ros-perception/calibration/pull/29/files#diff-75cdd0871abdb10aff724cfb002ff367L130)

openni2_launch publishes `camera/depth/image` and `camera/depth/image_raw` and `image` is 32FC1, but `mage_raw` is `16UC1`
