### PR TITLE
Remove unused dependency on Boost signals

### DIFF
--- a/image_cb_detector/CMakeLists.txt
+++ b/image_cb_detector/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(image_cb_detector)
 
-find_package(Boost REQUIRED thread signals)
+find_package(Boost REQUIRED thread)
 find_package(catkin REQUIRED actionlib actionlib_msgs calibration_msgs cv_bridge genmsg geometry_msgs image_transport message_filters roscpp sensor_msgs std_msgs)
 find_package(OpenCV REQUIRED)
 

--- a/laser_cb_detector/CMakeLists.txt
+++ b/laser_cb_detector/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(laser_cb_detector)
 
-find_package(Boost REQUIRED signals thread)
+find_package(Boost REQUIRED thread)
 find_package(catkin REQUIRED actionlib actionlib_msgs cv_bridge image_cb_detector message_filters roscpp settlerlib std_msgs)
 
 add_action_files(DIRECTORY action FILES Config.action)


### PR DESCRIPTION
The `image_cb_detector` and `laser_cb_detector` packages try to find the Boost signals library. This library is not used by these packages and has been deprecated since Boost 1.54 and was removed in Boost 1.69. This causes these packages to fail to build with the latest version of Boost.